### PR TITLE
Fix a bug where --no-emoji has no effect

### DIFF
--- a/src/meow/cli.py
+++ b/src/meow/cli.py
@@ -19,4 +19,4 @@ def main() -> None:
     args = parser.parse_args()
 
     # BUG: --no-emoji option is ignored (for workshop exercise)
-    meow(times=args.times, emoji=True)
+    meow(times=args.times, emoji=not args.no_emoji)


### PR DESCRIPTION
## What
- [ ] Fix tests
- [ ] Update docs if needed

## Why
`--no-emoji` option is not working as expect.

Fixes #12

## Checklist
- [x] I ran `pytest -q`
